### PR TITLE
add bridge networking build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ push: all
 	docker rmi push.$(REGISTRY)/apm/apm-server:$(VERSION_TAG)
 
 venv: requirements.txt
-	test -d venv || virtualenv --python=python3.5 venv
+	test -d venv || python3 -mvenv venv
 	pip install -r requirements.txt
 	touch venv
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This repository contains the official [APM Server][apm-server] Docker image from
 [elastic]: https://www.elastic.co/
 
 ## Requirements
-A full build and test requires:
+A full build requires:
 * Docker
 * GNU Make
-* Python 3.5 with Virtualenv
+* Python 3.3+ (3.5+ for tests)
 
 ## Supported Docker versions
 


### PR DESCRIPTION
To support building images under docker for mac, for testing.

Typical workflow:
```
# build packages
cd $GOPATH/src/github.com/elastic/apm-server
make package
# return to elastic/apm-server-docker
cd -
ARTIFACTS_DIR=$GOPATH/src/github.com/elastic make mac-release-snapshot
```

all ears for a better target name.