### PR TITLE
Use default apm-server.yml, but override elasticsearch output.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flake8==3.3.0
 jinja2-cli[yaml]==0.6.0
 jinja2==2.9.5
 testinfra==1.5.3
+pyyaml==3.12

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -14,7 +14,7 @@ RUN curl -Lso - {{ url }} | \
 ENV ELASTIC_CONTAINER true
 ENV PATH={{ home }}:$PATH
 
-COPY config {{ home }}
+RUN sed -i -e 's/hosts: \["localhost:9200"\]/hosts: ["elasticsearch:9200"]/g' {{ home }}/apm-server.yml
 
 # Add entrypoint wrapper script
 ADD docker-entrypoint /usr/local/bin

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -10,7 +10,7 @@ RUN yum update -y && yum install -y curl && yum clean all
 RUN curl -Lso - {{ url }} | \
       tar zxf - -C /tmp && \
       mv /tmp/apm-server-{{ version }}-linux-x86_64 {{ home }} && \
-      echo 'output.elasticsearch.hosts: ["elasticsearch:9200"]' >> {{ home }}/apm-server.yml
+      sed -zri 's/output.elasticsearch:(\n[^\n]*){2}/output.elasticsearch:\n  hosts: ["elasticsearch:9200"]/' {{ home }}/apm-server.yml
 
 ENV ELASTIC_CONTAINER true
 ENV PATH={{ home }}:$PATH

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -9,12 +9,11 @@ RUN yum update -y && yum install -y curl && yum clean all
 
 RUN curl -Lso - {{ url }} | \
       tar zxf - -C /tmp && \
-      mv /tmp/apm-server-{{ version }}-linux-x86_64 {{ home }}
+      mv /tmp/apm-server-{{ version }}-linux-x86_64 {{ home }} && \
+      echo 'output.elasticsearch.hosts: ["elasticsearch:9200"]' >> {{ home }}/apm-server.yml
 
 ENV ELASTIC_CONTAINER true
 ENV PATH={{ home }}:$PATH
-
-RUN sed -i -e 's/hosts: \["localhost:9200"\]/hosts: ["elasticsearch:9200"]/g' {{ home }}/apm-server.yml
 
 # Add entrypoint wrapper script
 ADD docker-entrypoint /usr/local/bin

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,3 +4,8 @@ from .fixtures import apm_server
 def test_config_file_passes_config_test(Command, apm_server):
     configtest = '%s -c %s -configtest' % (apm_server.binary_file.path, apm_server.config_file.path)
     Command.run_expect([0], configtest)
+
+
+def test_elasticsearch_output_points_to_elasticsearch_host(apm_server):
+    configured_hosts = apm_server.config['output']['elasticsearch']['hosts']
+    assert configured_hosts == ['elasticsearch:9200']


### PR DESCRIPTION
Use config file from downloaded tar.
Override elasticsearch output config to `elasticsearch:9200`
to avoid breaking change.

closes elastic/apm-server#776

-----------------------

At the moment the default config file for the docker image only defines very few settings. Other APM Server downloads are packaged with a more extensive default configuration file, including e.g. index patterns, more optimized memory queue settings, etc. 
This PR changes the docker image to also bundle the default configuration file to avoid different index creation and behavior than with other downloads. 

As the `output.elasticsearch.hosts` has been configured in the docker image so far, this setting stays the same. 
The `username` and `password` for the output are not pre-configured, as those should be changed by the user anyways.  

Users have following possibilities regarding configuration settings:
* default: 
`docker run docker.elastic.co/apm/apm-server:<version>`
  Starts the APM Server with using the packaged config yml.
* mound bind config file
`docker run -v ~/apm-server.yml:/usr/share/apm-server/apm-server.yml  docker.elastic.co/apm/apm-server:<version>`
  Overrides the packaged config yml with another config file. 
* override specific settings: 
`docker run -e -E output.elasticsearch.hosts=['localhost:9200']`
  Uses the packaged config yml but overrides the configured settings.