### PR TITLE
Remove `suid` bit to mitigate against stack clash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*/docker-entrypoint
 docker-compose.yml
 .cache
 **/__pycache__
+.pytest_cache

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -30,6 +30,9 @@ RUN mkdir data logs && \
     chmod 0750 {{ binary_file }} && \
     chmod 0770 data logs
 
+# Remove the suid bit everywhere it is set to mitigate against stackclash
+RUN find / -xdev -perm -4000 -exec chmod u-s {} +
+
 USER apm-server
 
 EXPOSE 8200

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,9 +2,14 @@ import subprocess
 import os
 
 
-def run(apm_server, command):
+def run(apm_server, command, elevated_privileges=False):
     image = 'docker.elastic.co/apm/%s:%s' % (apm_server.name, apm_server.tag)
-    cli = 'docker run --rm --interactive %s %s' % (image, command)
+
+    if elevated_privileges:
+        cli = 'docker run -u root --rm --interactive %s %s' % (image, command)
+    else:
+        cli = 'docker run --rm --interactive %s %s' % (image, command)
+
     result = subprocess.run(cli, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     result.stdout = result.stdout.rstrip()
     return result

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,5 @@
 from .fixtures import apm_server
+from .helpers import run
 import os
 
 
@@ -43,3 +44,10 @@ def test_log_dir_permissions(apm_server):
     assert apm_server.log_dir.user == 'root'
     assert apm_server.log_dir.group == apm_server.name
     assert apm_server.log_dir.mode == 0o0770
+
+
+def test_suid_bit_removed(apm_server):
+    cmd = run(apm_server, "find / -xdev -perm -4000", True)
+    assert cmd.returncode == 0
+    assert not cmd.stdout
+    assert not cmd.stderr


### PR DESCRIPTION
Removing the `suid` bit helps to mitigate against the stack clash vulnerability. See https://blog.qualys.com/securitylabs/2017/06/19/the-stack-clash for more details on stack clash.

This PR introduces a `RUN` command in the Dockerfile to remove the `suid` bit from all files. A new test is run to check that all files have the `suid` bit not enabled.